### PR TITLE
Remove trailing whitespace from the BOXES

### DIFF
--- a/icssh
+++ b/icssh
@@ -67,6 +67,9 @@ do
   BOXES="${BOXES}\"${IP}\" "
 done
 
+// Trim trailing whitespace
+BOXES="$(echo -e "${BOXES}" | sed -e 's/[[:space:]]*$//')"
+
 BOXES=$(echo $BOXES | sed 's| |,|g')
 BOXES="{${BOXES}}"
 


### PR DESCRIPTION
To avoid "321:322: syntax error: Expected expression but found “}”. (-2741)" where `$BOXES` being expanded to "{127.0.0.1,}"